### PR TITLE
Fix for conditional mutual information calculation

### DIFF
--- a/titanic.py
+++ b/titanic.py
@@ -128,6 +128,7 @@ def run_demo():
     sorted_scores = sorted(scores.items(), key=lambda pair: pair[1], reverse=True)
     dataset = dataset[[column[0] for column in sorted_scores[0:keep]] + ["survived"]]
     features = list(set(dataset.columns).difference(('survived',)))
+    features = sorted(features)
 
     # Build a QUBO that maximizes MI between survival and a subset of features
     bqm = dimod.BinaryQuadraticModel.empty(dimod.BINARY)

--- a/titanic.py
+++ b/titanic.py
@@ -76,7 +76,14 @@ def conditional_mutual_information(p, j, *conditional_indices):
 
     Calculated as I(X;Y|Z) = H(X|Z) - H(X|Y,Z)"""
 
-    return (conditional_shannon_entropy(np.sum(p, axis=j), *conditional_indices)
+    # Compute an updated version of the conditional indices for use
+    # when the probability table is marginalized over dimension j.
+    # This marginalization removes one dimension, so any conditional
+    # indices pointing to dimensions after this one must be adjusted
+    # accordingly.
+    marginal_conditional_indices = [i-1 if i > j else i for i in conditional_indices]
+
+    return (conditional_shannon_entropy(np.sum(p, axis=j), *marginal_conditional_indices)
             - conditional_shannon_entropy(p, j, *conditional_indices))
 
 def maximum_energy_delta(bqm):

--- a/titanic.py
+++ b/titanic.py
@@ -50,6 +50,12 @@ def shannon_entropy(p):
 def conditional_shannon_entropy(p, *conditional_indices):
     """Conditional Shannon entropy H(X|Y) = H(X,Y) - H(Y)."""
 
+    # Sanity check on validity of conditional_indices.  In particular,
+    # try to trap issues in which dimensions have been removed from
+    # probability table through marginalization, but
+    # conditional_indices were not updated accordingly.
+    assert(all(ci < p.ndim for ci in conditional_indices))
+
     axis = tuple(i for i in np.arange(len(p.shape))
                  if i not in conditional_indices)
 


### PR DESCRIPTION
Closes #11, which see for additional details regarding the problem.

This PR makes the following changes:

- An assertion has been added within `conditional_shannon_entropy` to trap invalid conditional indices.  This assertion fails with the previous version of the code.
- The conditional indices in `conditional_mutual_information` are adjusted to account for removal of one dimension of the probability table through marginalization.  This changes the resulting conditional mutual information values.
- The features are sorted by name prior to constructing the BQM, so that we get consistent ordering across runs.

Note that this fix produces a significant change in the CMI values.  By failing to condition on the correct indices after marginalizing, I believe that what was being computed previously was `H(X_i) - H(X_i | C, X_j)`, when instead what we want is `I(X_i ; C | X_j) = H(X_i | X_j) - H(X_i | C, X_j)`.  With this correction to the CMI values, the solution to the feature selection problem changes for some feature sizes `k`.

Following is a selection of CMI sums for comparing before and after this fix.  For each pair of variables, I list the sum `I(X_i ; C | X_j) + I(X_j ; C | X_i)`, which, after negation, sets the interaction term in the QUBO formulation.

Before fix:
```
miss mr 1.8738331378565012
miss mrs 1.6367431635613354
miss pclass 2.436817324088781
miss sex 1.842336452584508
mr mrs 1.7767961871653437
mr pclass 2.837309682388892
mr sex 1.9797020049653606
mrs pclass 2.3131467569015975
mrs sex 1.7212057641560299
pclass sex 2.7982133982587496
```

After fix:
```
miss mr 0.15306890219562064
miss mrs 0.26428695937652336
miss pclass 0.18777663472320483
miss sex 0.1611597388411934
mr mrs 0.14261145560735256
mr pclass 0.32654046565013695
mr sex 0.036796763848866876
mrs pclass 0.1506855716389106
mrs sex 0.1266085545156046
pclass sex 0.32703170343756005
```