### PR TITLE
Add verification cases for mutual information calcs

### DIFF
--- a/tests/test_titanic.py
+++ b/tests/test_titanic.py
@@ -46,16 +46,16 @@ class TestTwoDimensionalCalcs(unittest.TestCase):
         self.assertAlmostEqual(shannon_entropy(np.sum(self.prob, axis=0)), self.hy)
 
     def test_conditional_shannon_entropy(self):
-        # H(X | Y) = H(X,Y) - H(Y)
+        # H(X|Y) = H(X,Y) - H(Y)
         self.assertAlmostEqual(conditional_shannon_entropy(self.prob, 1), self.hxy - self.hy)
-        # H(Y | X) = H(X,Y) - H(X)
+        # H(Y|X) = H(X,Y) - H(X)
         self.assertAlmostEqual(conditional_shannon_entropy(self.prob, 0), self.hxy - self.hx)
 
     def test_mutual_information(self):
-        # I(X; Y) = H(X) - H(X | Y)
-        # H(X | Y) = H(X, Y) - H(Y)
+        # I(X;Y) = H(X) - H(X|Y)
+        # H(X|Y) = H(X,Y) - H(Y)
         expected = self.hx - (self.hxy - self.hy)
-        # Note: I(X ; Y) = I(Y ; X)
+        # Note: I(X;Y) = I(Y;X)
         self.assertAlmostEqual(mutual_information(self.prob, 0), expected)
         self.assertAlmostEqual(mutual_information(self.prob, 1), expected)
 

--- a/tests/test_titanic.py
+++ b/tests/test_titanic.py
@@ -108,8 +108,6 @@ class TestThreeDimensionalCalcs(unittest.TestCase):
         # I(X;Y|Z) = I(Y;X|Z)
         self.assertAlmostEqual(conditional_mutual_information(self.p, 0, 2), cmi)
 
-
-class TestTitanicFunctions(unittest.TestCase):
     def test_prob(self):
         data = np.array([[True, 0, 4],
                          [True, 2, 3],
@@ -135,7 +133,6 @@ class TestTitanicFunctions(unittest.TestCase):
         self.assertEqual(np.sum(flat_prob), 1)   # probabilities sum to 1
         self.assertEqual(np.sum(flat_prob==0.4), 1)
         self.assertEqual(np.sum(flat_prob==0.2), 3)
-
 
 
 class TestTitanicDemo(unittest.TestCase):

--- a/tests/test_titanic.py
+++ b/tests/test_titanic.py
@@ -23,6 +23,19 @@ from titanic import (prob, shannon_entropy, conditional_shannon_entropy,
                      mutual_information, conditional_mutual_information)
 
 
+class TestTwoDimensionalCalcs(unittest.TestCase):
+    """Verify entropy and mutual information calculations for two random variables."""
+    @classmethod
+    def setUpClass(cls):
+        cls.prob = np.array([[0.5, 0], [0.3, 0.2]])
+
+    def test_shannon_entropy(self):
+        result = shannon_entropy(self.prob)
+
+        expected = -0.5*np.log2(0.5) - 0.3*np.log2(0.3) -0.2*np.log2(0.2)
+        self.assertAlmostEqual(result, expected)
+
+
 class TestTitanicFunctions(unittest.TestCase):
     def test_prob(self):
         data = np.array([[True, 0, 4],
@@ -49,13 +62,6 @@ class TestTitanicFunctions(unittest.TestCase):
         self.assertEqual(np.sum(flat_prob), 1)   # probabilities sum to 1
         self.assertEqual(np.sum(flat_prob==0.4), 1)
         self.assertEqual(np.sum(flat_prob==0.2), 3)
-
-    def test_shannon_entropy(self):
-        prob = np.array([[0.5, 0], [0.3, 0.2]])
-        result = shannon_entropy(prob)
-
-        expected = -0.5*np.log2(0.5) - 0.3*np.log2(0.3) -0.2*np.log2(0.2)
-        self.assertAlmostEqual(result, expected)
 
     def test_conditional_shannon_entropy(self):
         p = np.array([[[0.2, 0.0],

--- a/tests/test_titanic.py
+++ b/tests/test_titanic.py
@@ -45,6 +45,12 @@ class TestTwoDimensionalCalcs(unittest.TestCase):
 
         self.assertAlmostEqual(shannon_entropy(np.sum(self.prob, axis=0)), self.hy)
 
+    def test_conditional_shannon_entropy(self):
+        # H(X | Y) = H(X,Y) - H(Y)
+        self.assertAlmostEqual(conditional_shannon_entropy(self.prob, 1), self.hxy - self.hy)
+        # H(Y | X) = H(X,Y) - H(X)
+        self.assertAlmostEqual(conditional_shannon_entropy(self.prob, 0), self.hxy - self.hx)
+
     def test_mutual_information(self):
         # I(X; Y) = H(X) - H(X | Y)
         # H(X | Y) = H(X, Y) - H(Y)

--- a/tests/test_titanic.py
+++ b/tests/test_titanic.py
@@ -27,13 +27,31 @@ class TestTwoDimensionalCalcs(unittest.TestCase):
     """Verify entropy and mutual information calculations for two random variables."""
     @classmethod
     def setUpClass(cls):
+        # Probability table for use in verification:
         cls.prob = np.array([[0.5, 0], [0.3, 0.2]])
 
-    def test_shannon_entropy(self):
+        # Directly calculated values, for verification:
+        cls.hxy = -0.5*np.log2(0.5) - 0.3*np.log2(0.3) -0.2*np.log2(0.2)
+        cls.hx = -0.5*np.log2(0.5) - 0.5*np.log2(0.5)
+        cls.hy = -0.8*np.log2(0.8) - 0.2*np.log2(0.2)
+
+    def test_joint_shannon_entropy(self):
         result = shannon_entropy(self.prob)
 
-        expected = -0.5*np.log2(0.5) - 0.3*np.log2(0.3) -0.2*np.log2(0.2)
-        self.assertAlmostEqual(result, expected)
+        self.assertAlmostEqual(result, self.hxy)
+
+    def test_marginal_shannon_entropy(self):
+        self.assertAlmostEqual(shannon_entropy(np.sum(self.prob, axis=1)), self.hx)
+
+        self.assertAlmostEqual(shannon_entropy(np.sum(self.prob, axis=0)), self.hy)
+
+    def test_mutual_information(self):
+        # I(X; Y) = H(X) - H(X | Y)
+        # H(X | Y) = H(X, Y) - H(Y)
+        expected = self.hx - (self.hxy - self.hy)
+        # Note: I(X ; Y) = I(Y ; X)
+        self.assertAlmostEqual(mutual_information(self.prob, 0), expected)
+        self.assertAlmostEqual(mutual_information(self.prob, 1), expected)
 
 
 class TestTitanicFunctions(unittest.TestCase):
@@ -87,9 +105,6 @@ class TestTitanicFunctions(unittest.TestCase):
 
         result = conditional_shannon_entropy(p, 0)
         self.assertAlmostEqual(result, expected)
-
-    def test_mutual_information(self):
-        pass
 
     def test_conditional_mutual_information(self):
         pass

--- a/tests/test_titanic.py
+++ b/tests/test_titanic.py
@@ -54,8 +54,7 @@ class TestTitanicFunctions(unittest.TestCase):
         prob = np.array([[0.5, 0], [0.3, 0.2]])
         result = shannon_entropy(prob)
 
-        # -0.5*np.log2(0.5) - 0.3*np.log2(0.3) -0.2*np.log2(0.2)
-        expected = 1.4854752972273344
+        expected = -0.5*np.log2(0.5) - 0.3*np.log2(0.3) -0.2*np.log2(0.2)
         self.assertAlmostEqual(result, expected)
 
     def test_conditional_shannon_entropy(self):


### PR DESCRIPTION
Additional verification cases for entropy, mutual information, and conditional mutual information calculations.  Have also reorganized the unit tests slightly to group them under two classes: `TestTwoDimensionalCalcs` and `TestThreeDimensionalCalcs`.  Diffs are a little tough to interpret due to some existing code getting moved around, but the additions are:
- Tests for Shannon entropy after marginalizing
- Additional tests on conditional Shannon entropy
- Test mutual information and verify symmetry (previously this was an empty placeholder)
- Test conditional mutual information (previously this was an empty placeholder)

(The previous functions `test_prob` and `test_conditional_shannon_entropy` have been kept as is but moved under the new `TestThreeDimensionalCalcs` class.)